### PR TITLE
Bugfix for destination functions with globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,13 @@ module.exports = class {
       if (file.isDirectory()) {
         return void callback(null, file)
       }
-      if (destPath instanceof Function) destPath = destPath(file)
-      const writeFilePath = path.posix.join('/', destPath, file.relative).replace(/\\/g, '/')
+      let realDestPath
+      if (destPath instanceof Function) {
+        realDestPath = destPath(file)
+      } else {
+        realDestPath = destPath    
+      }
+      const writeFilePath = path.posix.join('/', realDestPath, file.relative).replace(/\\/g, '/')
       const createDirPath = path.posix.dirname(writeFilePath)
       this._log(`Creating directory "${createDirPath}" in memory.`)
       this.fs.mkdirpSync(createDirPath)


### PR DESCRIPTION
The destPath argument is call by reference and shouldn't be overwritten.

When destPath is a function and there are multiple files, it is being resolved for the first file only, and then for subsequent files the destPath argument is a string - which is bad if those files would have resolved to a different path.

Example code where this causes a problem:

```js
gulp.src('./src/posts/**/*.md')
  .pipe(frontMatter())
  .pipe(markdown())
  .pipe( ... )
  .pipe(rename('index.html'))
  .pipe(gulpMem.dest(file => {
    console.log('file', file.frontMatter.url);
    return './public/blog/' + file.frontMatter.url
  })));
```
